### PR TITLE
Reduce final library file size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 
 [profile.release]
 strip = true
+opt-level = "z"
+lto = true
+codegen-units = 1
+panic = "abort"
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
Small changes, which will decrease file size at the cost of longer compile time.

I may potentially revert these changes in the future, though going from a 3.1M to 2.1M file is nice (still massive compared to the native C plugins for `rofi` though)